### PR TITLE
Copyright header FIX

### DIFF
--- a/src/main/java/walkingkooka/storage/StorageName.java
+++ b/src/main/java/walkingkooka/storage/StorageName.java
@@ -15,23 +15,6 @@
  *
  */
 
-/*
- * Copyright 2019 Miroslav Pokorny (github.com/mP1)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
-
 package walkingkooka.storage;
 
 import walkingkooka.Cast;

--- a/src/main/java/walkingkooka/storage/StoragePath.java
+++ b/src/main/java/walkingkooka/storage/StoragePath.java
@@ -15,23 +15,6 @@
  *
  */
 
-/*
- * Copyright 2019 Miroslav Pokorny (github.com/mP1)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
-
 package walkingkooka.storage;
 
 import walkingkooka.compare.Comparators;

--- a/src/test/java/walkingkooka/storage/StorageNameTest.java
+++ b/src/test/java/walkingkooka/storage/StorageNameTest.java
@@ -15,23 +15,6 @@
  *
  */
 
-/*
- * Copyright 2019 Miroslav Pokorny (github.com/mP1)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
-
 package walkingkooka.storage;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/walkingkooka/storage/StoragePathTest.java
+++ b/src/test/java/walkingkooka/storage/StoragePathTest.java
@@ -14,24 +14,6 @@
  * limitations under the License.
  *
  */
-
-/*
- * Copyright 2019 Miroslav Pokorny (github.com/mP1)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
-
 package walkingkooka.storage;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
- Duplicated with 2019 and 2025, deleted former.