### PR TITLE
StorageName.ROOT="" was "/"

### DIFF
--- a/src/main/java/walkingkooka/storage/StorageName.java
+++ b/src/main/java/walkingkooka/storage/StorageName.java
@@ -42,9 +42,9 @@ public final class StorageName implements Name,
 
     public final static int MAX_LENGTH = 255;
 
-    final static StorageName ROOT = new StorageName(
-        StoragePath.SEPARATOR_STRING
-    );
+    final static String ROOT_NAME = "";
+
+    final static StorageName ROOT = new StorageName(ROOT_NAME);
 
     private final static CharPredicate CHARACTERS = CharPredicates.printable().andNot(
         CharPredicates.is(
@@ -56,18 +56,16 @@ public final class StorageName implements Name,
      * Factory that creates a new {@link StorageName}
      */
     public static StorageName with(final String name) {
-        InvalidTextLengthException.throwIfFail(
-            "name",
-            name,
-            MIN_LENGTH,
-            MAX_LENGTH
-        );
-
-        return name.equals(StoragePath.SEPARATOR_STRING) ?
+        return ROOT.value().equals(name) ?
             ROOT :
             new StorageName(
                 CharPredicates.failIfNullOrEmptyOrInitialAndPartFalse(
-                    name,
+                    InvalidTextLengthException.throwIfFail(
+                        "name",
+                        name,
+                        MIN_LENGTH,
+                        MAX_LENGTH
+                    ),
                     "name",
                     CHARACTERS, // initial
                     CHARACTERS // part

--- a/src/main/java/walkingkooka/storage/StoragePath.java
+++ b/src/main/java/walkingkooka/storage/StoragePath.java
@@ -56,8 +56,8 @@ final public class StoragePath
     );
 
     /**
-     * Parses the {@link String} into a {@link StoragePath}. Not path navigation components such as DOT and DOUBLE DOT
-     * are processed and the path normalized.
+     * Parses the {@link String} into a {@link StoragePath}. Not path navigation components such as EMPTY, DOT and
+     * DOUBLE DOT are processed and the path normalized.
      */
     public static StoragePath parse(final String path) {
         SEPARATOR.checkBeginning(path);
@@ -128,7 +128,7 @@ final public class StoragePath
         final StoragePath prepended;
 
         switch (name.value()) {
-            case SEPARATOR_STRING:
+            case StorageName.ROOT_NAME:
                 prepended = this;
                 break;
             case CURRENT:
@@ -165,7 +165,7 @@ final public class StoragePath
         StoragePath appended;
 
         switch (name.value()) {
-            case SEPARATOR_STRING:
+            case StorageName.ROOT_NAME:
                 appended = this;
                 break;
             case CURRENT:

--- a/src/test/java/walkingkooka/storage/StorageNameTest.java
+++ b/src/test/java/walkingkooka/storage/StorageNameTest.java
@@ -35,11 +35,16 @@ public final class StorageNameTest implements ClassTesting2<StorageName>,
 
     // with.............................................................................................................
 
+    @Override
+    public void testEmptyFails() {
+        throw new UnsupportedOperationException();
+    }
+
     @Test
     public void testWithRoot() {
         assertSame(
             StorageName.ROOT,
-            StorageName.with("/")
+            StorageName.with("")
         );
     }
 
@@ -135,21 +140,6 @@ public final class StorageNameTest implements ClassTesting2<StorageName>,
     @Override
     public String possibleInvalidChars(final int i) {
         return CONTROL;
-    }
-
-    // MIN_LENGTH.......................................................................................................
-
-    @Test
-    public void testWithMinLengthFails() {
-        final IllegalArgumentException thrown = assertThrows(
-            IllegalArgumentException.class,
-            () -> StorageName.with("")
-        );
-
-        this.checkEquals(
-            "Empty \"name\"",
-            thrown.getMessage()
-        );
     }
 
     // MAX_LENGTH.......................................................................................................

--- a/src/test/java/walkingkooka/storage/StoragePathTest.java
+++ b/src/test/java/walkingkooka/storage/StoragePathTest.java
@@ -58,14 +58,6 @@ final public class StoragePathTest implements PathTesting<StoragePath, StorageNa
     }
 
     @Test
-    public void testParseEmptyComponentFails() {
-        this.parseStringFails(
-            "/before//after",
-            IllegalArgumentException.class
-        );
-    }
-
-    @Test
     public void testParseSlash() {
         final String value = "/";
 
@@ -96,6 +88,23 @@ final public class StoragePathTest implements PathTesting<StoragePath, StorageNa
         this.parentSame(
             path,
             StoragePath.ROOT
+        );
+    }
+
+    @Test
+    public void testParseEmptyComponentNormalized() {
+        final String value = "/path1//path2";
+
+        final StoragePath path = StoragePath.parse(value);
+        this.valueCheck(path, "/path1/path2"); // normalized
+        this.rootNotCheck(path);
+        this.nameCheck(
+            path,
+            StorageName.with("path2")
+        );
+        this.parentCheck(
+            path,
+            "/path1"
         );
     }
 


### PR DESCRIPTION
- Matches other Path implementations where the Name.ROOT is empty string and not separator.