### PR TITLE
Revert "Storage: StorageContext type-parameter removed"

### DIFF
--- a/src/main/java/walkingkooka/storage/EmptyStorage.java
+++ b/src/main/java/walkingkooka/storage/EmptyStorage.java
@@ -27,9 +27,9 @@ import java.util.Optional;
 /**
  * A {@link Storage} that is always empty and does not support saving, and deletes will fail.
  */
-final class EmptyStorage implements Storage {
+final class EmptyStorage<C extends StorageContext> implements Storage<C> {
 
-    static EmptyStorage instance() {
+    static <C extends StorageContext> EmptyStorage<C> instance() {
         return INSTANCE;
     }
 
@@ -46,7 +46,7 @@ final class EmptyStorage implements Storage {
 
     @Override
     public Optional<StorageValue> load(final StoragePath path,
-                                       final StorageContext context) {
+                                       final C context) {
         Objects.requireNonNull(path, "path");
         Objects.requireNonNull(context, "context");
 
@@ -55,7 +55,7 @@ final class EmptyStorage implements Storage {
 
     @Override
     public StorageValue save(final StorageValue value,
-                             final StorageContext context) {
+                             final C context) {
         Objects.requireNonNull(value, "value");
         Objects.requireNonNull(context, "context");
 
@@ -64,7 +64,7 @@ final class EmptyStorage implements Storage {
 
     @Override
     public void delete(final StoragePath path,
-                       final StorageContext context) {
+                       final C context) {
         Objects.requireNonNull(path, "path");
         Objects.requireNonNull(context, "context");
 
@@ -75,7 +75,7 @@ final class EmptyStorage implements Storage {
     public List<StorageValueInfo> list(final StoragePath parent,
                                        final int offset,
                                        final int count,
-                                       final StorageContext context) {
+                                       final C context) {
         Objects.requireNonNull(parent, "parent");
         Store.checkOffsetAndCount(offset, count);
         Objects.requireNonNull(context, "context");

--- a/src/main/java/walkingkooka/storage/FakeStorage.java
+++ b/src/main/java/walkingkooka/storage/FakeStorage.java
@@ -20,7 +20,7 @@ package walkingkooka.storage;
 import java.util.List;
 import java.util.Optional;
 
-public class FakeStorage implements Storage {
+public class FakeStorage<C extends StorageContext> implements Storage<C> {
 
     public FakeStorage() {
         super();
@@ -28,19 +28,19 @@ public class FakeStorage implements Storage {
 
     @Override
     public Optional<StorageValue> load(final StoragePath path,
-                                       final StorageContext context) {
+                                       final C context) {
         throw new UnsupportedOperationException();
     }
 
     @Override
     public StorageValue save(final StorageValue value,
-                             final StorageContext context) {
+                             final C context) {
         throw new UnsupportedOperationException();
     }
 
     @Override
     public void delete(final StoragePath path,
-                       final StorageContext context) {
+                       final C context) {
         throw new UnsupportedOperationException();
     }
 
@@ -48,7 +48,7 @@ public class FakeStorage implements Storage {
     public List<StorageValueInfo> list(final StoragePath parent,
                                        final int offset,
                                        final int count,
-                                       final StorageContext context) {
+                                       final C context) {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/walkingkooka/storage/PrefixedStorage.java
+++ b/src/main/java/walkingkooka/storage/PrefixedStorage.java
@@ -29,28 +29,28 @@ import java.util.stream.Collectors;
  * {@link StorageValueInfo}.
  * This is particularly useful for a {@link Storage} that unites one or more {@link Storage} at different mount points.
  */
-final class PrefixedStorage implements Storage {
+final class PrefixedStorage<C extends StorageContext> implements Storage<C> {
 
-    static Storage with(final StoragePath prefix,
-                        final Storage storage) {
+    static <C extends StorageContext> Storage<C> with(final StoragePath prefix,
+                                                      final Storage<C> storage) {
         Objects.requireNonNull(prefix, "prefix");
         Objects.requireNonNull(storage, "storage");
 
-        final Storage result;
+        final Storage<C> result;
 
         if (prefix.equals(StoragePath.ROOT)) {
             result = storage;
         } else {
             StoragePath wrapPrefix = prefix;
-            Storage wrapStoraage = storage;
+            Storage<C> wrapStoraage = storage;
 
             if (storage instanceof PrefixedStorage) {
-                final PrefixedStorage prefixedStorage = (PrefixedStorage) storage;
+                final PrefixedStorage<C> prefixedStorage = (PrefixedStorage<C>) storage;
                 wrapPrefix = prefix.append(prefixedStorage.prefix);
                 wrapStoraage = prefixedStorage.storage;
             }
 
-            result = new PrefixedStorage(
+            result = new PrefixedStorage<C>(
                 wrapPrefix,
                 wrapStoraage
             );
@@ -60,14 +60,14 @@ final class PrefixedStorage implements Storage {
     }
 
     private PrefixedStorage(final StoragePath prefix,
-                            final Storage storage) {
+                            final Storage<C> storage) {
         this.prefix = prefix;
         this.storage = storage;
     }
 
     @Override
     public Optional<StorageValue> load(final StoragePath path,
-                                       final StorageContext context) {
+                                       final C context) {
         Objects.requireNonNull(path, "path");
         Objects.requireNonNull(context, "context");
 
@@ -81,7 +81,7 @@ final class PrefixedStorage implements Storage {
 
     @Override
     public StorageValue save(final StorageValue value,
-                             final StorageContext context) {
+                             final C context) {
         return this.storage.save(
             value.removePrefixPath(this.prefix),
             context
@@ -90,7 +90,7 @@ final class PrefixedStorage implements Storage {
 
     @Override
     public void delete(final StoragePath path,
-                       final StorageContext context) {
+                       final C context) {
         Objects.requireNonNull(path, "path");
         Objects.requireNonNull(context, "context");
 
@@ -104,7 +104,7 @@ final class PrefixedStorage implements Storage {
     public List<StorageValueInfo> list(final StoragePath parent,
                                        final int offset,
                                        final int count,
-                                       final StorageContext context) {
+                                       final C context) {
         Objects.requireNonNull(parent, "parent");
         Store.checkOffsetAndCount(
             offset,
@@ -126,7 +126,7 @@ final class PrefixedStorage implements Storage {
     final StoragePath prefix;
 
     // @VisibleForTesting
-    final Storage storage;
+    final Storage<C> storage;
 
     // Object...........................................................................................................
 

--- a/src/main/java/walkingkooka/storage/RoutingStorageBuilder.java
+++ b/src/main/java/walkingkooka/storage/RoutingStorageBuilder.java
@@ -26,9 +26,9 @@ import java.util.List;
 /**
  * A {@link Builder} that may be used to add one more mounted {@link Storage}.
  */
-public final class RoutingStorageBuilder implements Builder<Storage> {
+public final class RoutingStorageBuilder<C extends StorageContext> implements Builder<Storage<C>> {
 
-    public static RoutingStorageBuilder empty() {
+    public static <C extends StorageContext> RoutingStorageBuilder<C> empty() {
         return new RoutingStorageBuilder();
     }
 
@@ -40,14 +40,14 @@ public final class RoutingStorageBuilder implements Builder<Storage> {
      * Adds a mount at the given path. If this mount is shadowed by previous addition a {@link IllegalArgumentException}
      * will be thrown.
      */
-    public RoutingStorageBuilder startsWith(final StoragePath path,
-                                            final Storage store) {
-        final RoutingStorageRoute newRoute = RoutingStorageRoute.with(
+    public RoutingStorageBuilder<C> startsWith(final StoragePath path,
+                                               final Storage store) {
+        final RoutingStorageRoute<C> newRoute = RoutingStorageRoute.with(
             path,
             store
         );
 
-        for (final RoutingStorageRoute route : this.routes) {
+        for (final RoutingStorageRoute<C> route : this.routes) {
             if (route.isMatch(path)) {
                 throw new IllegalArgumentException("Invalid path " + path.quotedAppendedWithStar() + " would be shadowed by " + route);
             }
@@ -58,8 +58,8 @@ public final class RoutingStorageBuilder implements Builder<Storage> {
     }
 
     @Override
-    public Storage build() throws BuilderException {
-        final List<RoutingStorageRoute> copy = Lists.array();
+    public Storage<C> build() throws BuilderException {
+        final List<RoutingStorageRoute<C>> copy = Lists.array();
         copy.addAll(this.routes);
 
         switch (copy.size()) {
@@ -70,7 +70,7 @@ public final class RoutingStorageBuilder implements Builder<Storage> {
         }
     }
 
-    private final List<RoutingStorageRoute> routes;
+    private final List<RoutingStorageRoute<C>> routes;
 
     @Override
     public String toString() {

--- a/src/main/java/walkingkooka/storage/RoutingStorageRoute.java
+++ b/src/main/java/walkingkooka/storage/RoutingStorageRoute.java
@@ -22,21 +22,21 @@ import java.util.Objects;
 /**
  * A single mount within a {@link RoutingStorage}.
  */
-final class RoutingStorageRoute {
+final class RoutingStorageRoute<C extends StorageContext> {
 
-    static RoutingStorageRoute with(final StoragePath path,
-                                    final Storage store) {
+    static <C extends StorageContext> RoutingStorageRoute<C> with(final StoragePath path,
+                                                                  final Storage<C> store) {
         Objects.requireNonNull(path, "path");
         Objects.requireNonNull(store, "store");
 
-        return new RoutingStorageRoute(
+        return new RoutingStorageRoute<>(
             path,
             store
         );
     }
 
     private RoutingStorageRoute(final StoragePath path,
-                                final Storage store) {
+                                final Storage<C> store) {
         super();
         this.path = path;
         this.store = store;
@@ -82,7 +82,7 @@ final class RoutingStorageRoute {
 
     final StoragePath path;
 
-    final Storage store;
+    final Storage<C> store;
 
     // Object...........................................................................................................
 

--- a/src/main/java/walkingkooka/storage/Storage.java
+++ b/src/main/java/walkingkooka/storage/Storage.java
@@ -23,16 +23,16 @@ import java.util.Optional;
 /**
  * A {@link Storage} that supports storing values including support for tree or directory structure.
  */
-public interface Storage {
+public interface Storage<C extends StorageContext> {
 
     Optional<StorageValue> load(final StoragePath path,
-                                final StorageContext context);
+                                final C context);
 
     StorageValue save(final StorageValue value,
-                      final StorageContext context);
+                      final C context);
 
     void delete(final StoragePath path,
-                final StorageContext context);
+                final C context);
 
     /**
      * Gets the {@link StorageValueInfo} for the given range.<br>
@@ -41,12 +41,12 @@ public interface Storage {
     List<StorageValueInfo> list(final StoragePath parent,
                                 final int offset,
                                 final int count,
-                                final StorageContext context);
+                                final C context);
 
     /**
      * Returns a {@link Storage} with an additional prefix to all its {@link StoragePath}.
      */
-    default Storage setPrefix(final StoragePath prefix) {
+    default Storage<C> setPrefix(final StoragePath prefix) {
         return PrefixedStorage.with(
             prefix,
             this

--- a/src/main/java/walkingkooka/storage/StorageTesting.java
+++ b/src/main/java/walkingkooka/storage/StorageTesting.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public interface StorageTesting<S extends Storage, C extends StorageContext> extends ClassTesting<S>,
+public interface StorageTesting<S extends Storage<C>, C extends StorageContext> extends ClassTesting<S>,
     TreePrintableTesting {
 
     // load.............................................................................................................
@@ -56,7 +56,7 @@ public interface StorageTesting<S extends Storage, C extends StorageContext> ext
         );
     }
 
-    default void loadAndCheck(final Storage storage,
+    default void loadAndCheck(final Storage<C> storage,
                               final StoragePath path,
                               final C context) {
         this.loadAndCheck(
@@ -67,7 +67,7 @@ public interface StorageTesting<S extends Storage, C extends StorageContext> ext
         );
     }
 
-    default void loadAndCheck(final Storage storage,
+    default void loadAndCheck(final Storage<C> storage,
                               final StoragePath path,
                               final C context,
                               final StorageValue expected) {
@@ -79,7 +79,7 @@ public interface StorageTesting<S extends Storage, C extends StorageContext> ext
         );
     }
 
-    default void loadAndCheck(final Storage storage,
+    default void loadAndCheck(final Storage<C> storage,
                               final StoragePath path,
                               final C context,
                               final Optional<StorageValue> expected) {
@@ -119,7 +119,7 @@ public interface StorageTesting<S extends Storage, C extends StorageContext> ext
         );
     }
 
-    default void saveAndCheck(final Storage storage,
+    default void saveAndCheck(final Storage<C> storage,
                               final StorageValue value,
                               final C context,
                               final StorageValue expected) {
@@ -227,7 +227,7 @@ public interface StorageTesting<S extends Storage, C extends StorageContext> ext
         );
     }
 
-    default void listAndCheck(final Storage storage,
+    default void listAndCheck(final Storage<C> storage,
                               final StoragePath parent,
                               final int offset,
                               final int count,
@@ -243,7 +243,7 @@ public interface StorageTesting<S extends Storage, C extends StorageContext> ext
         );
     }
 
-    default void listAndCheck(final Storage storage,
+    default void listAndCheck(final Storage<C> storage,
                               final StoragePath parent,
                               final int offset,
                               final int count,

--- a/src/main/java/walkingkooka/storage/Storages.java
+++ b/src/main/java/walkingkooka/storage/Storages.java
@@ -27,22 +27,22 @@ public final class Storages implements PublicStaticHelper {
     /**
      * {@see EmptyStorage}
      */
-    public static Storage empty() {
+    public static <C extends StorageContext> Storage<C> empty() {
         return EmptyStorage.instance();
     }
 
     /**
      * {@see FakeStorage}
      */
-    public static Storage fake() {
-        return new FakeStorage();
+    public static <C extends StorageContext> Storage<C> fake() {
+        return new FakeStorage<>();
     }
 
     /**
      * {@see PrefixedStorage}
      */
-    public static Storage prefixed(final StoragePath prefix,
-                                   final Storage storage) {
+    public static <C extends StorageContext> Storage<C> prefixed(final StoragePath prefix,
+                                                                 final Storage<C> storage) {
         return PrefixedStorage.with(
             prefix,
             storage
@@ -52,7 +52,7 @@ public final class Storages implements PublicStaticHelper {
     /**
      * {@see TreeMapStoreStorage}
      */
-    public static Storage tree() {
+    public static <C extends StorageContext> Storage<C> tree() {
         return TreeMapStoreStorage.empty();
     }
 

--- a/src/main/java/walkingkooka/storage/TreeMapStoreStorage.java
+++ b/src/main/java/walkingkooka/storage/TreeMapStoreStorage.java
@@ -27,10 +27,10 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-final class TreeMapStoreStorage implements Storage {
+final class TreeMapStoreStorage<C extends StorageContext> implements Storage<C> {
 
-    static TreeMapStoreStorage empty() {
-        return new TreeMapStoreStorage();
+    static <C extends StorageContext> TreeMapStoreStorage<C> empty() {
+        return new TreeMapStoreStorage<>();
     }
 
     private TreeMapStoreStorage() {
@@ -47,7 +47,7 @@ final class TreeMapStoreStorage implements Storage {
 
     @Override
     public Optional<StorageValue> load(final StoragePath path,
-                                       final StorageContext context) {
+                                       final C context) {
         Objects.requireNonNull(path, "path");
         Objects.requireNonNull(context, "context");
 
@@ -57,7 +57,7 @@ final class TreeMapStoreStorage implements Storage {
 
     @Override
     public StorageValue save(final StorageValue value,
-                             final StorageContext context) {
+                             final C context) {
         Objects.requireNonNull(value, "storageValue");
         Objects.requireNonNull(context, "context");
 
@@ -125,7 +125,7 @@ final class TreeMapStoreStorage implements Storage {
 
     @Override
     public void delete(final StoragePath path,
-                       final StorageContext context) {
+                       final C context) {
         Objects.requireNonNull(path, "path");
         Objects.requireNonNull(context, "context");
 
@@ -136,7 +136,7 @@ final class TreeMapStoreStorage implements Storage {
     public List<StorageValueInfo> list(final StoragePath parent,
                                        final int offset,
                                        final int count,
-                                       final StorageContext context) {
+                                       final C context) {
         Objects.requireNonNull(parent, "parent");
         Store.checkOffsetAndCount(offset, count);
         Objects.requireNonNull(context, "context");

--- a/src/test/java/walkingkooka/storage/EmptyStorageTest.java
+++ b/src/test/java/walkingkooka/storage/EmptyStorageTest.java
@@ -24,8 +24,8 @@ import walkingkooka.reflect.JavaVisibility;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class EmptyStorageTest implements StorageTesting<EmptyStorage, StorageContext>,
-    ToStringTesting<EmptyStorage> {
+public final class EmptyStorageTest implements StorageTesting<EmptyStorage<StorageContext>, StorageContext>,
+    ToStringTesting<EmptyStorage<StorageContext>> {
 
     @Test
     public void testLoadMissing() {
@@ -97,7 +97,7 @@ public final class EmptyStorageTest implements StorageTesting<EmptyStorage, Stor
     // class............................................................................................................
 
     @Override
-    public Class<EmptyStorage> type() {
+    public Class<EmptyStorage<StorageContext>> type() {
         return Cast.to(EmptyStorage.class);
     }
 

--- a/src/test/java/walkingkooka/storage/PrefixedStorageTest.java
+++ b/src/test/java/walkingkooka/storage/PrefixedStorageTest.java
@@ -29,8 +29,8 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class PrefixedStorageTest implements StorageTesting<PrefixedStorage, FakeStorageContext>,
-    ToStringTesting<PrefixedStorage> {
+public final class PrefixedStorageTest implements StorageTesting<PrefixedStorage<FakeStorageContext>, FakeStorageContext>,
+    ToStringTesting<PrefixedStorage<FakeStorageContext>> {
 
     private final static String PREFIX = "/prefix111";
 
@@ -69,7 +69,7 @@ public final class PrefixedStorageTest implements StorageTesting<PrefixedStorage
 
     @Test
     public void testWithRoot() {
-        final Storage storage = Storages.fake();
+        final Storage<FakeStorageContext> storage = Storages.fake();
 
         assertSame(
             storage,
@@ -82,11 +82,11 @@ public final class PrefixedStorageTest implements StorageTesting<PrefixedStorage
 
     @Test
     public void testWithPrefixedStorage() {
-        final PrefixedStorage storage = this.createStorage();
+        final PrefixedStorage<FakeStorageContext> storage = this.createStorage();
 
         final StoragePath prefix2 = StoragePath.parse("/prefix222");
 
-        final PrefixedStorage prefixedStorage = Cast.to(
+        final PrefixedStorage<FakeStorageContext> prefixedStorage = Cast.to(
             PrefixedStorage.with(
                 prefix2,
                 storage
@@ -119,7 +119,7 @@ public final class PrefixedStorageTest implements StorageTesting<PrefixedStorage
 
     @Test
     public void testLoad() {
-        final PrefixedStorage storage = this.createStorage();
+        final PrefixedStorage<FakeStorageContext> storage = this.createStorage();
         final FakeStorageContext context = this.createContext();
 
         final StorageValue value = StorageValue.with(
@@ -146,7 +146,7 @@ public final class PrefixedStorageTest implements StorageTesting<PrefixedStorage
 
     @Test
     public void testSave() {
-        final PrefixedStorage storage = this.createStorage();
+        final PrefixedStorage<FakeStorageContext> storage = this.createStorage();
         final FakeStorageContext context = this.createContext();
 
         final StoragePath path = StoragePath.parse(PREFIX + "/value111");
@@ -177,7 +177,7 @@ public final class PrefixedStorageTest implements StorageTesting<PrefixedStorage
 
     @Test
     public void testDeleteWithUnknownPath() {
-        final PrefixedStorage storage = this.createStorage();
+        final PrefixedStorage<FakeStorageContext> storage = this.createStorage();
         final FakeStorageContext context = this.createContext();
 
         final StoragePath path = StoragePath.parse("/value111");
@@ -207,7 +207,7 @@ public final class PrefixedStorageTest implements StorageTesting<PrefixedStorage
 
     @Test
     public void testDelete() {
-        final PrefixedStorage storage = this.createStorage();
+        final PrefixedStorage<FakeStorageContext> storage = this.createStorage();
         final FakeStorageContext context = this.createContext();
 
         final StoragePath path = StoragePath.parse("/value111");
@@ -238,7 +238,7 @@ public final class PrefixedStorageTest implements StorageTesting<PrefixedStorage
 
     @Test
     public void testList() {
-        final PrefixedStorage storage = this.createStorage();
+        final PrefixedStorage<FakeStorageContext> storage = this.createStorage();
         final FakeStorageContext context = this.createContext();
 
         final StoragePath path1 = StoragePath.parse(PREFIX + "/value111");
@@ -303,7 +303,7 @@ public final class PrefixedStorageTest implements StorageTesting<PrefixedStorage
     }
 
     @Override
-    public PrefixedStorage createStorage() {
+    public PrefixedStorage<FakeStorageContext> createStorage() {
         return Cast.to(
             PrefixedStorage.with(
                 StoragePath.parse(PREFIX),
@@ -342,7 +342,7 @@ public final class PrefixedStorageTest implements StorageTesting<PrefixedStorage
     // class............................................................................................................
 
     @Override
-    public Class<PrefixedStorage> type() {
+    public Class<PrefixedStorage<FakeStorageContext>> type() {
         return Cast.to(PrefixedStorage.class);
     }
 

--- a/src/test/java/walkingkooka/storage/RoutingStorageBuilderTest.java
+++ b/src/test/java/walkingkooka/storage/RoutingStorageBuilderTest.java
@@ -23,11 +23,11 @@ import walkingkooka.build.BuilderTesting;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class RoutingStorageBuilderTest implements BuilderTesting<RoutingStorageBuilder, Storage> {
+public final class RoutingStorageBuilderTest implements BuilderTesting<RoutingStorageBuilder<StorageContext>, Storage<StorageContext>> {
 
     private final static StoragePath PATH = StoragePath.ROOT;
 
-    private final static Storage STORE = new FakeStorage() {
+    private final static Storage<StorageContext> STORE = new FakeStorage<>() {
 
         @Override
         public String toString() {
@@ -63,7 +63,7 @@ public final class RoutingStorageBuilderTest implements BuilderTesting<RoutingSt
 
     @Test
     public void testStartWithShadowedFails() {
-        final RoutingStorageBuilder builder = RoutingStorageBuilder.empty()
+        final RoutingStorageBuilder<StorageContext> builder = RoutingStorageBuilder.empty()
             .startsWith(
                 PATH,
                 STORE
@@ -87,7 +87,7 @@ public final class RoutingStorageBuilderTest implements BuilderTesting<RoutingSt
     public void testStartWithShadowedFails2() {
         final StoragePath path = StoragePath.parse("/mount111");
 
-        final RoutingStorageBuilder builder = RoutingStorageBuilder.empty()
+        final RoutingStorageBuilder<StorageContext> builder = RoutingStorageBuilder.empty()
             .startsWith(
                 path,
                 STORE
@@ -111,7 +111,7 @@ public final class RoutingStorageBuilderTest implements BuilderTesting<RoutingSt
     public void testStartWithShadowedFails3() {
         final StoragePath path = StoragePath.parse("/mount222");
 
-        final RoutingStorageBuilder builder = RoutingStorageBuilder.empty()
+        final RoutingStorageBuilder<StorageContext> builder = RoutingStorageBuilder.empty()
             .startsWith(
                 StoragePath.parse("/mount111"),
                 STORE
@@ -136,7 +136,7 @@ public final class RoutingStorageBuilderTest implements BuilderTesting<RoutingSt
 
     @Test
     public void testStartsWith() {
-        final RoutingStorageBuilder builder = RoutingStorageBuilder.empty()
+        final RoutingStorageBuilder<StorageContext> builder = RoutingStorageBuilder.empty()
             .startsWith(
                 StoragePath.parse("/mount111"),
                 STORE
@@ -148,7 +148,7 @@ public final class RoutingStorageBuilderTest implements BuilderTesting<RoutingSt
 
     @Test
     public void testStartsWith2() {
-        final RoutingStorageBuilder builder = RoutingStorageBuilder.empty()
+        final RoutingStorageBuilder<StorageContext> builder = RoutingStorageBuilder.empty()
             .startsWith(
                 StoragePath.parse("/mount111/xyz"),
                 STORE
@@ -162,7 +162,7 @@ public final class RoutingStorageBuilderTest implements BuilderTesting<RoutingSt
 
     @Test
     public void testBuild() {
-        final RoutingStorageBuilder builder = RoutingStorageBuilder.empty()
+        final RoutingStorageBuilder<StorageContext> builder = RoutingStorageBuilder.empty()
             .startsWith(
                 StoragePath.parse("/mount111/xyz"),
                 STORE
@@ -174,19 +174,19 @@ public final class RoutingStorageBuilderTest implements BuilderTesting<RoutingSt
     }
 
     @Override
-    public RoutingStorageBuilder createBuilder() {
+    public RoutingStorageBuilder<StorageContext> createBuilder() {
         return RoutingStorageBuilder.empty();
     }
 
     @Override
-    public Class<Storage> builderProductType() {
+    public Class<Storage<StorageContext>> builderProductType() {
         return Cast.to(Storage.class);
     }
 
     // class............................................................................................................
 
     @Override
-    public Class<RoutingStorageBuilder> type() {
+    public Class<RoutingStorageBuilder<StorageContext>> type() {
         return Cast.to(RoutingStorageBuilder.class);
     }
 }

--- a/src/test/java/walkingkooka/storage/RoutingStorageTest.java
+++ b/src/test/java/walkingkooka/storage/RoutingStorageTest.java
@@ -28,7 +28,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-public final class RoutingStorageTest implements StorageTesting<RoutingStorage, StorageContext> {
+public final class RoutingStorageTest implements StorageTesting<RoutingStorage<StorageContext>, StorageContext> {
 
     private final static LocalDateTime NOW = LocalDateTime.of(
         1999,
@@ -56,9 +56,9 @@ public final class RoutingStorageTest implements StorageTesting<RoutingStorage, 
 
     @Test
     public void testSave() {
-        final Storage store1 = Storages.tree();
+        final Storage<StorageContext> store1 = Storages.tree();
 
-        final RoutingStorage routingStorageStore = this.createStorage(
+        final RoutingStorage<StorageContext> routingStorageStore = this.createStorage(
             store1,
             Storages.fake()
         );
@@ -84,9 +84,9 @@ public final class RoutingStorageTest implements StorageTesting<RoutingStorage, 
 
     @Test
     public void testSaveExtraLongPath() {
-        final Storage store1 = Storages.tree();
+        final Storage<StorageContext> store1 = Storages.tree();
 
-        final RoutingStorage routingStorageStore = this.createStorage(
+        final RoutingStorage<StorageContext> routingStorageStore = this.createStorage(
             store1,
             Storages.fake()
         );
@@ -142,9 +142,9 @@ public final class RoutingStorageTest implements StorageTesting<RoutingStorage, 
 
     @Test
     public void testSave2ndMount() {
-        final Storage store1 = Storages.tree();
+        final Storage<StorageContext> store1 = Storages.tree();
 
-        final RoutingStorage routingStorageStore = this.createStorage(
+        final RoutingStorage<StorageContext> routingStorageStore = this.createStorage(
             Storages.fake(),
             store1
         );
@@ -170,9 +170,9 @@ public final class RoutingStorageTest implements StorageTesting<RoutingStorage, 
 
     @Test
     public void testSaveAndLoad() {
-        final Storage store1 = Storages.tree();
+        final Storage<StorageContext> store1 = Storages.tree();
 
-        final RoutingStorage routingStorageStore = this.createStorage(
+        final RoutingStorage<StorageContext> routingStorageStore = this.createStorage(
             store1,
             Storages.fake()
         );
@@ -197,9 +197,9 @@ public final class RoutingStorageTest implements StorageTesting<RoutingStorage, 
 
     @Test
     public void testSaveAndLoadExtraLongPath() {
-        final Storage store1 = Storages.tree();
+        final Storage<StorageContext> store1 = Storages.tree();
 
-        final RoutingStorage routingStorageStore = this.createStorage(
+        final RoutingStorage<StorageContext> routingStorageStore = this.createStorage(
             store1,
             Storages.fake()
         );
@@ -224,9 +224,9 @@ public final class RoutingStorageTest implements StorageTesting<RoutingStorage, 
 
     @Test
     public void testSaveAndDelete() {
-        final Storage store1 = Storages.tree();
+        final Storage<StorageContext> store1 = Storages.tree();
 
-        final RoutingStorage routingStorageStore = this.createStorage(
+        final RoutingStorage<StorageContext> routingStorageStore = this.createStorage(
             store1,
             Storages.fake()
         );
@@ -263,10 +263,10 @@ public final class RoutingStorageTest implements StorageTesting<RoutingStorage, 
 
     @Test
     public void testAddDeleteSaveAndDelete() {
-        final Storage store1 = Storages.tree();
-        final Storage store2 = Storages.tree();
+        final Storage<StorageContext> store1 = Storages.tree();
+        final Storage<StorageContext> store2 = Storages.tree();
 
-        final RoutingStorage routingStorageStore = this.createStorage(
+        final RoutingStorage<StorageContext> routingStorageStore = this.createStorage(
             store1,
             store2
         );
@@ -313,10 +313,10 @@ public final class RoutingStorageTest implements StorageTesting<RoutingStorage, 
 
     @Test
     public void testList() {
-        final Storage store1 = Storages.tree();
-        final Storage store2 = Storages.tree();
+        final Storage<StorageContext> store1 = Storages.tree();
+        final Storage<StorageContext> store2 = Storages.tree();
 
-        final RoutingStorage routingStorageStore = this.createStorage(
+        final RoutingStorage<StorageContext> routingStorageStore = this.createStorage(
             store1,
             store2
         );
@@ -384,10 +384,10 @@ public final class RoutingStorageTest implements StorageTesting<RoutingStorage, 
 
     @Test
     public void testListSubDirectoryOfMount() {
-        final Storage store1 = Storages.tree();
-        final Storage store2 = Storages.tree();
+        final Storage<StorageContext> store1 = Storages.tree();
+        final Storage<StorageContext> store2 = Storages.tree();
 
-        final RoutingStorage routingStorageStore = this.createStorage(
+        final RoutingStorage<StorageContext> routingStorageStore = this.createStorage(
             store1,
             store2
         );
@@ -444,21 +444,21 @@ public final class RoutingStorageTest implements StorageTesting<RoutingStorage, 
     }
 
     @Override
-    public RoutingStorage createStorage() {
+    public RoutingStorage<StorageContext> createStorage() {
         return this.createStorage(
             Storages.tree(),// /mount1
             Storages.tree() // /mount2
         );
     }
 
-    private RoutingStorage createStorage(final Storage... stores) {
+    private RoutingStorage<StorageContext> createStorage(final Storage<StorageContext>... stores) {
         return this.createStorage(
             Lists.of(stores)
         );
     }
 
-    private RoutingStorage createStorage(final List<Storage> stores) {
-        final RoutingStorageBuilder b = RoutingStorageBuilder.empty();
+    private RoutingStorage<StorageContext> createStorage(final List<Storage<StorageContext>> stores) {
+        final RoutingStorageBuilder<StorageContext> b = RoutingStorageBuilder.empty();
 
         int i = 1;
         for (Storage store : stores) {
@@ -470,7 +470,7 @@ public final class RoutingStorageTest implements StorageTesting<RoutingStorage, 
             i++;
         }
 
-        return (RoutingStorage) b.build();
+        return (RoutingStorage<StorageContext>) b.build();
     }
 
     @Override
@@ -506,7 +506,7 @@ public final class RoutingStorageTest implements StorageTesting<RoutingStorage, 
     // class............................................................................................................
 
     @Override
-    public Class<RoutingStorage> type() {
+    public Class<RoutingStorage<StorageContext>> type() {
         return Cast.to(RoutingStorage.class);
     }
 

--- a/src/test/java/walkingkooka/storage/TreeMapStoreStorageTest.java
+++ b/src/test/java/walkingkooka/storage/TreeMapStoreStorageTest.java
@@ -28,7 +28,7 @@ import java.time.LocalDateTime;
 import java.util.Objects;
 import java.util.Optional;
 
-public class TreeMapStoreStorageTest implements StorageTesting<TreeMapStoreStorage, TestStorageContext> {
+public class TreeMapStoreStorageTest implements StorageTesting<TreeMapStoreStorage<TestStorageContext>, TestStorageContext> {
 
     private final static StoragePath PATH = StoragePath.parse("/path123");
 
@@ -50,7 +50,7 @@ public class TreeMapStoreStorageTest implements StorageTesting<TreeMapStoreStora
 
     @Test
     public void testSaveAndLoad() {
-        final TreeMapStoreStorage store = this.createStorage();
+        final TreeMapStoreStorage<TestStorageContext> store = this.createStorage();
         final TestStorageContext context = new TestStorageContext();
 
         final StorageValue value = STORAGE_VALUE;
@@ -70,7 +70,7 @@ public class TreeMapStoreStorageTest implements StorageTesting<TreeMapStoreStora
 
     @Test
     public void testBuildPathSaveAndLoad() {
-        final TreeMapStoreStorage store = this.createStorage();
+        final TreeMapStoreStorage<TestStorageContext> store = this.createStorage();
         final TestStorageContext context = new TestStorageContext();
 
         final StoragePath base = StoragePath.parse("/base");
@@ -112,7 +112,7 @@ public class TreeMapStoreStorageTest implements StorageTesting<TreeMapStoreStora
 
     @Test
     public void testSaveAndList() {
-        final TreeMapStoreStorage store = this.createStorage();
+        final TreeMapStoreStorage<TestStorageContext> store = this.createStorage();
         final TestStorageContext context = new TestStorageContext();
 
         final StorageValue value = STORAGE_VALUE;
@@ -138,7 +138,7 @@ public class TreeMapStoreStorageTest implements StorageTesting<TreeMapStoreStora
 
     @Test
     public void testSaveAndListMixedParents() {
-        final TreeMapStoreStorage store = this.createStorage();
+        final TreeMapStoreStorage<TestStorageContext> store = this.createStorage();
         final TestStorageContext context = new TestStorageContext();
 
         final StoragePath base = StoragePath.parse("/base");
@@ -270,7 +270,7 @@ public class TreeMapStoreStorageTest implements StorageTesting<TreeMapStoreStora
 
     @Test
     public void testListRootPath() {
-        final TreeMapStoreStorage store = this.createStorage();
+        final TreeMapStoreStorage<TestStorageContext> store = this.createStorage();
         final TestStorageContext context = new TestStorageContext();
 
         final StoragePath file1 = StoragePath.parse("/file1.txt");
@@ -320,7 +320,7 @@ public class TreeMapStoreStorageTest implements StorageTesting<TreeMapStoreStora
 
     @Test
     public void testListSubdirectory() {
-        final TreeMapStoreStorage store = this.createStorage();
+        final TreeMapStoreStorage<TestStorageContext> store = this.createStorage();
         final TestStorageContext context = new TestStorageContext();
 
         final StoragePath file1 = StoragePath.parse("/file1.txt");
@@ -377,7 +377,7 @@ public class TreeMapStoreStorageTest implements StorageTesting<TreeMapStoreStora
     }
 
     @Override
-    public TreeMapStoreStorage createStorage() {
+    public TreeMapStoreStorage<TestStorageContext> createStorage() {
         return TreeMapStoreStorage.empty();
     }
 
@@ -414,7 +414,7 @@ public class TreeMapStoreStorageTest implements StorageTesting<TreeMapStoreStora
     // class............................................................................................................
 
     @Override
-    public Class<TreeMapStoreStorage> type() {
+    public Class<TreeMapStoreStorage<TestStorageContext>> type() {
         return Cast.to(TreeMapStoreStorage.class);
     }
 


### PR DESCRIPTION
This reverts commit 3a172ddce670428bfaed0efe8bbc89f257050432.

- Removing type-parameter was a mistake because SpreadsheetTerminalStorage requires a SpreadsheetTerminalStorageContext