### PR TITLE
StorageValue unimplements Comparable

### DIFF
--- a/src/main/java/walkingkooka/storage/StorageValue.java
+++ b/src/main/java/walkingkooka/storage/StorageValue.java
@@ -44,7 +44,6 @@ public final class StorageValue implements HasContentType,
     HasValue<Optional<Object>>,
     HasId<Optional<StoragePath>>,
     HasPath<StoragePath>,
-    Comparable<StorageValue>,
     TreePrintable {
 
     public final static Optional<Object> NO_VALUE = Optional.empty();
@@ -211,13 +210,6 @@ public final class StorageValue implements HasContentType,
             .separator(" ")
             .value(this.contentType)
             .build();
-    }
-
-    // Comparable.......................................................................................................
-
-    @Override
-    public int compareTo(final StorageValue other) {
-        return this.path.compareTo(other.path());
     }
 
     // TreePrintable....................................................................................................


### PR DESCRIPTION
- Unnecessary no Storage is using a StorageValue as a Comparable.
- Was also "hiding" TreePrinting.checkEquals as only StoragePath equality was performed.
- See previous commits in this repo for Converters in last hour or so.