### PR TITLE
StorageConverterStorageBinaryToStorageValueSharedXXX: assign contentT…

### DIFF
--- a/src/main/java/walkingkooka/storage/convert/StorageConverterStorageBinaryToStorageValueShared.java
+++ b/src/main/java/walkingkooka/storage/convert/StorageConverterStorageBinaryToStorageValueShared.java
@@ -60,17 +60,20 @@ abstract class StorageConverterStorageBinaryToStorageValueShared<C extends Stora
                                                      final Class<T> type,
                                                      final Object value,
                                                      final Optional<MediaType> contentType) {
-        StorageValue storageValue = StorageValue.with(
-            storagePath
-        ).setValue(
-            Optional.of(value)
-        );
-        if(contentType.isPresent()) {
-            storageValue = storageValue.setContentType(contentType);
-        }
 
+        // if $contentType is missing use #contentType
         return this.successfulConversion(
-            storageValue,
+            StorageValue.with(
+                storagePath
+            ).setValue(
+                Optional.of(value)
+            ).setContentType(
+                contentType.isPresent() ?
+                    contentType :
+                    Optional.of(
+                        this.contentType()
+                    )
+            ),
             type
         );
     }

--- a/src/test/java/walkingkooka/storage/StorageSharedNativeFileTest.java
+++ b/src/test/java/walkingkooka/storage/StorageSharedNativeFileTest.java
@@ -40,6 +40,7 @@ import walkingkooka.math.DecimalNumberContext;
 import walkingkooka.math.DecimalNumberContexts;
 import walkingkooka.math.MathTesting;
 import walkingkooka.net.email.EmailAddress;
+import walkingkooka.net.header.MediaType;
 import walkingkooka.net.header.MediaTypeDetectors;
 import walkingkooka.props.Properties;
 import walkingkooka.props.PropertiesPath;
@@ -209,6 +210,8 @@ public final class StorageSharedNativeFileTest extends StorageSharedTestCase<Sto
             StorageValue.with(storagePath)
                 .setValue(
                     Optional.of(PROPERTIES)
+                ).setContentType(
+                    Optional.of(MediaType.TEXT_PROPERTIES)
                 )
         );
     }
@@ -224,6 +227,8 @@ public final class StorageSharedNativeFileTest extends StorageSharedTestCase<Sto
             StorageValue.with(storagePath)
                 .setValue(
                     Optional.of(TEXT_CONTENT)
+                ).setContentType(
+                    Optional.of(MediaType.TEXT_PLAIN)
                 )
         );
     }
@@ -311,7 +316,9 @@ public final class StorageSharedNativeFileTest extends StorageSharedTestCase<Sto
             storage,
             storagePath,
             context,
-            storageValue
+            storageValue.setContentType(
+                Optional.of(MediaType.TEXT_PROPERTIES)
+            )
         );
     }
 
@@ -337,7 +344,9 @@ public final class StorageSharedNativeFileTest extends StorageSharedTestCase<Sto
             storage,
             storagePath,
             context,
-            storageValue
+            storageValue.setContentType(
+                Optional.of(MediaType.TEXT_PLAIN)
+            )
         );
     }
 
@@ -533,6 +542,8 @@ public final class StorageSharedNativeFileTest extends StorageSharedTestCase<Sto
             StoragePath.parse("/different.txt")
         ).setValue(
             Optional.of("different " + TEXT_CONTENT)
+        ).setContentType(
+            Optional.of(MediaType.TEXT_PLAIN)
         );
 
         storage.addWatcher(

--- a/src/test/java/walkingkooka/storage/convert/StorageConverterStorageBinaryToStorageValueSharedCsvTest.java
+++ b/src/test/java/walkingkooka/storage/convert/StorageConverterStorageBinaryToStorageValueSharedCsvTest.java
@@ -58,6 +58,8 @@ public final class StorageConverterStorageBinaryToStorageValueSharedCsvTest exte
             StorageValue.with(storagePath)
                 .setValue(
                     Optional.of(list)
+                ).setContentType(
+                    Optional.of(MediaType.TEXT_CSV)
                 )
         );
     }

--- a/src/test/java/walkingkooka/storage/convert/StorageConverterStorageBinaryToStorageValueSharedPropertiesTest.java
+++ b/src/test/java/walkingkooka/storage/convert/StorageConverterStorageBinaryToStorageValueSharedPropertiesTest.java
@@ -58,6 +58,8 @@ public final class StorageConverterStorageBinaryToStorageValueSharedPropertiesTe
             StorageValue.with(storagePath)
                 .setValue(
                     Optional.of(dateTimeSymbols)
+                ).setContentType(
+                    Optional.of(MediaType.TEXT_PROPERTIES)
                 )
         );
     }
@@ -85,7 +87,9 @@ public final class StorageConverterStorageBinaryToStorageValueSharedPropertiesTe
             StorageValue.with(storagePath)
                 .setValue(
                     Optional.of(properties)
-                ).clearContentType()
+                ).setContentType(
+                    Optional.of(MediaType.TEXT_PROPERTIES)
+                )
         );
     }
 

--- a/src/test/java/walkingkooka/storage/convert/StorageConverterStorageBinaryToStorageValueSharedTsvTest.java
+++ b/src/test/java/walkingkooka/storage/convert/StorageConverterStorageBinaryToStorageValueSharedTsvTest.java
@@ -25,6 +25,7 @@ import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.list.TsvStringList;
 import walkingkooka.convert.Converter;
 import walkingkooka.convert.Converters;
+import walkingkooka.net.header.MediaType;
 import walkingkooka.storage.StorageBinary;
 import walkingkooka.storage.StoragePath;
 import walkingkooka.storage.StorageValue;
@@ -57,6 +58,8 @@ public final class StorageConverterStorageBinaryToStorageValueSharedTsvTest exte
             StorageValue.with(storagePath)
                 .setValue(
                     Optional.of(list)
+                ).setContentType(
+                    Optional.of(MediaType.TEXT_TAB_SEPARATED_VALUES)
                 )
         );
     }

--- a/src/test/java/walkingkooka/storage/convert/StorageConverterStorageBinaryToStorageValueSharedTxtTest.java
+++ b/src/test/java/walkingkooka/storage/convert/StorageConverterStorageBinaryToStorageValueSharedTxtTest.java
@@ -54,7 +54,9 @@ public final class StorageConverterStorageBinaryToStorageValueSharedTxtTest exte
             StorageValue.with(storagePath)
                 .setValue(
                     Optional.of(text)
-                ).clearContentType()
+                ).setContentType(
+                    Optional.of(MediaType.TEXT_PLAIN)
+                )
         );
     }
 


### PR DESCRIPTION
…ype if missing

- CLoses https://github.com/mP1/walkingkooka-storage/issues/504
- Converters: StorageConverterStorageBinaryToStorageValueSharedXXX should try detect content type if necessary