### PR TITLE
StorageSharedTreeMapStore.list Storage path without slash FIX

### DIFF
--- a/src/main/java/walkingkooka/storage/StorageSharedTreeMapStore.java
+++ b/src/main/java/walkingkooka/storage/StorageSharedTreeMapStore.java
@@ -21,6 +21,7 @@ import walkingkooka.environment.AuditInfo;
 import walkingkooka.store.Store;
 import walkingkooka.store.StoreWatcher;
 import walkingkooka.store.Stores;
+import walkingkooka.text.CharSequences;
 
 import java.util.Comparator;
 import java.util.List;
@@ -113,7 +114,15 @@ final class StorageSharedTreeMapStore<C extends StorageContext> extends StorageS
                 .orElse(null);
 
             while (null != parentPath && false == parentPath.isRoot()) {
-                final StorageSharedTreeMapStoreValue parent = store.load(parentPath)
+                final StoragePath parentPathWithoutSlash = StoragePath.parse(
+                    CharSequences.subSequence(
+                        parentPath.value(),
+                        0,
+                        -1
+                    ).toString()
+                );
+
+                final StorageSharedTreeMapStoreValue parent = store.load(parentPathWithoutSlash)
                     .orElse(null);
                 if (null != parent) {
                     break;
@@ -123,10 +132,10 @@ final class StorageSharedTreeMapStore<C extends StorageContext> extends StorageS
                 store.save(
                     StorageSharedTreeMapStoreValue.with(
                         StorageValueInfo.with(
-                            parentPath,
+                            parentPathWithoutSlash,
                             context.createdAuditInfo()
                         ),
-                        StorageValue.with(parentPath)
+                        StorageValue.with(parentPathWithoutSlash)
                     )
                 );
 

--- a/src/test/java/walkingkooka/storage/StorageSharedTreeMapStoreTest.java
+++ b/src/test/java/walkingkooka/storage/StorageSharedTreeMapStoreTest.java
@@ -408,7 +408,7 @@ public class StorageSharedTreeMapStoreTest extends StorageSharedTestCase<Storage
             4,
             context,
             StorageValueInfo.with(
-                StoragePath.parse("/dir2/"),
+                StoragePath.parse("/dir2"),
                 AUDIT_INFO
             ),
             StorageValueInfo.with(
@@ -419,7 +419,63 @@ public class StorageSharedTreeMapStoreTest extends StorageSharedTestCase<Storage
     }
 
     @Test
-    public void testListSubdirectory() {
+    public void testListStorage() {
+        final StorageSharedTreeMapStore<TestStorageContext> storage = this.createStorage();
+        final TestStorageContext context = new TestStorageContext();
+
+        final StoragePath file1 = StoragePath.parse("/file1.txt");
+        storage.save(
+            StorageValue.with(file1)
+                .setValue(
+                    Optional.of("file1-value")
+                ),
+            context
+        );
+
+        final StoragePath file2 = StoragePath.parse("/dir2/file2.txt");
+        storage.save(
+            StorageValue.with(file2)
+                .setValue(
+                    Optional.of("file2-value")
+                ),
+            context
+        );
+
+        final StoragePath file3 = StoragePath.parse("/dir2/file3.txt");
+        storage.save(
+            StorageValue.with(file3)
+                .setValue(
+                    Optional.of("file3-value")
+                ),
+            context
+        );
+
+        final StoragePath file4 = StoragePath.parse("/dir4/file4.txt");
+        storage.save(
+            StorageValue.with(file4)
+                .setValue(
+                    Optional.of("file4-value")
+                ),
+            context
+        );
+
+        final StoragePath parent = StoragePath.parse("/dir2");
+
+        this.listAndCheck(
+            storage,
+            parent,
+            0,
+            10,
+            context,
+            StorageValueInfo.with(
+                parent,
+                AUDIT_INFO
+            )
+        );
+    }
+
+    @Test
+    public void testListStorageSlash() {
         final StorageSharedTreeMapStore<TestStorageContext> storage = this.createStorage();
         final TestStorageContext context = new TestStorageContext();
 

--- a/src/test/java/walkingkooka/storage/StorageSharedWrapperExplodedZipFileTest.java
+++ b/src/test/java/walkingkooka/storage/StorageSharedWrapperExplodedZipFileTest.java
@@ -25,6 +25,7 @@ import walkingkooka.HasCharsetTesting;
 import walkingkooka.environment.AuditInfo;
 import walkingkooka.net.email.EmailAddress;
 import walkingkooka.storage.StorageSharedWrapperExplodedZipFileTest.TestStorageContext;
+import walkingkooka.text.CharSequences;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -182,8 +183,15 @@ public final class StorageSharedWrapperExplodedZipFileTest extends StorageShared
             4,
             new TestStorageContext(),
             StorageValueInfo.with(
-                FILE_STORAGE_PATH.parent()
-                    .get(),
+                StoragePath.parse(
+                    CharSequences.subSequence(
+                        FILE_STORAGE_PATH.parent()
+                            .get()
+                            .value(),
+                        0,
+                        -1
+                    ).toString()
+                ),
                 AUDIT_INFO
             )
         );


### PR DESCRIPTION
- Previously listing a storage path that exists "/dir" returned nothing. Listing children worked.