### PR TITLE
StoragePath.parent never has trailing slash FIX

### DIFF
--- a/src/main/java/walkingkooka/storage/StoragePath.java
+++ b/src/main/java/walkingkooka/storage/StoragePath.java
@@ -18,6 +18,7 @@
 package walkingkooka.storage;
 
 import walkingkooka.InvalidTextLengthException;
+import walkingkooka.collect.list.Lists;
 import walkingkooka.compare.Comparators;
 import walkingkooka.naming.Path;
 import walkingkooka.naming.PathSeparator;
@@ -32,6 +33,7 @@ import walkingkooka.tree.json.marshall.JsonNodeContext;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallContext;
 import walkingkooka.tree.json.marshall.JsonNodeUnmarshallContext;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -64,6 +66,8 @@ final public class StoragePath
             MAX_LENGTH
         );
     }
+
+    final static char SEPARATOR_CHAR = '/';
 
     final static String SEPARATOR_STRING = "/";
 
@@ -105,17 +109,15 @@ final public class StoragePath
 
     private static StoragePath parseNonRoot(final String path) {
         try {
-            StoragePath storagePath = ROOT;
-
             final int length = path.length();
             int nameStart = 1; // must start with slash
 
-            final StringBuilder b = new StringBuilder()
-                .append(SEPARATOR);
+            final List<StorageName> names = Lists.array();
 
+            // capture StorageNames and normalize as well
             while (nameStart < length) {
                 final int next = path.indexOf(
-                    SEPARATOR.character(),
+                    SEPARATOR_CHAR,
                     nameStart
                 );
 
@@ -125,7 +127,7 @@ final public class StoragePath
                         (
                             path.charAt(
                                 length - 1
-                            ) == SEPARATOR.character() ?
+                            ) == SEPARATOR_CHAR ?
                                 1 :
                                 0
                         );
@@ -141,24 +143,13 @@ final public class StoragePath
                         case CURRENT:
                             break;
                         case PARENT:
-                            storagePath = storagePath.parent()
-                                .orElse(ROOT);
-
-                            b.setLength(
-                                storagePath.path.length()
+                            names.remove(
+                                names.size() - 1
                             );
                             break;
                         default:
-                            b.append(name);
-
-                            if (-1 != next) {
-                                b.append(SEPARATOR_STRING);
-                            }
-
-                            storagePath = with(
-                                b.toString(),
-                                StorageName.with(name),
-                                Optional.ofNullable(storagePath)
+                            names.add(
+                                StorageName.with(name)
                             );
                             break;
                     }
@@ -169,6 +160,29 @@ final public class StoragePath
                 }
 
                 nameStart = next + 1;
+            }
+
+            // build actual StoragePath with normalized name components
+            StoragePath storagePath = ROOT;
+
+            int lastCountdown = path.endsWith(SEPARATOR_STRING) ?
+                names.size() :
+                Integer.MAX_VALUE;
+            final StringBuilder pathBuilder = new StringBuilder();
+
+            for(final StorageName name : names) {
+                pathBuilder.append(SEPARATOR_CHAR);
+                pathBuilder.append(name.value());
+
+                if(--lastCountdown == 0) {
+                    pathBuilder.append(SEPARATOR_CHAR);
+                }
+
+                storagePath = new StoragePath(
+                    pathBuilder.toString(), // path
+                    name,
+                    Optional.of(storagePath) // parent
+                );
             }
 
             return storagePath;
@@ -291,6 +305,27 @@ final public class StoragePath
 
     private final String path;
 
+    /**
+     * Helper that removes the trailing SLASH from parent paths.
+     * <pre>
+     * /path1/path2/
+     * /path1/path2
+     * </pre>
+     */
+    StoragePath parentWithoutTrailingSeparator() {
+        return this.isRoot() || this.isValue() ?
+            this :
+            new StoragePath(
+                CharSequences.subSequence(
+                    this.path,
+                    0,
+                    -1
+                ).toString(),
+                this.name,
+                this.parent
+            );
+    }
+
     // removePrefix.....................................................................................................
 
     /**
@@ -386,7 +421,8 @@ final public class StoragePath
                 appended = this.parent.orElse(ROOT);
                 break;
             default:
-                appended = this.appendNonRootName(name);
+                appended = this.parentWithoutTrailingSeparator()
+                    .appendNonRootName(name);
                 break;
         }
 
@@ -396,7 +432,7 @@ final public class StoragePath
     private StoragePath appendNonRootName(final StorageName name) {
         final StringBuilder path = new StringBuilder();
         path.append(this.path);
-        if (false == this.isRoot()) {
+        if (false == this.isParent()) {
             path.append(SEPARATOR);
         }
         path.append(

--- a/src/main/java/walkingkooka/storage/StorageSharedTreeMapStore.java
+++ b/src/main/java/walkingkooka/storage/StorageSharedTreeMapStore.java
@@ -21,14 +21,12 @@ import walkingkooka.environment.AuditInfo;
 import walkingkooka.store.Store;
 import walkingkooka.store.StoreWatcher;
 import walkingkooka.store.Stores;
-import walkingkooka.text.CharSequences;
 
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * A {@link Storage} that uses a {@link Stores#treeMap(Comparator, BiFunction)} to hold {@link StoragePath} to
@@ -102,6 +100,7 @@ final class StorageSharedTreeMapStore<C extends StorageContext> extends StorageS
         } else {
             // set creator and modified
             newSave = StorageSharedTreeMapStoreValue.with(
+                StorageSharedTreeMapStoreValue.NOT_PARENT,
                 StorageValueInfo.with(
                     path,
                     context.createdAuditInfo()
@@ -114,13 +113,7 @@ final class StorageSharedTreeMapStore<C extends StorageContext> extends StorageS
                 .orElse(null);
 
             while (null != parentPath && false == parentPath.isRoot()) {
-                final StoragePath parentPathWithoutSlash = StoragePath.parse(
-                    CharSequences.subSequence(
-                        parentPath.value(),
-                        0,
-                        -1
-                    ).toString()
-                );
+                final StoragePath parentPathWithoutSlash = parentPath;
 
                 final StorageSharedTreeMapStoreValue parent = store.load(parentPathWithoutSlash)
                     .orElse(null);
@@ -131,6 +124,7 @@ final class StorageSharedTreeMapStore<C extends StorageContext> extends StorageS
                 // create parent entry
                 store.save(
                     StorageSharedTreeMapStoreValue.with(
+                        StorageSharedTreeMapStoreValue.PARENT,
                         StorageValueInfo.with(
                             parentPathWithoutSlash,
                             context.createdAuditInfo()
@@ -154,7 +148,16 @@ final class StorageSharedTreeMapStore<C extends StorageContext> extends StorageS
         if(path.isParent()) {
             throw path.invalidStoragePathException("Invalid parent path");
         }
-        this.store.delete(path);
+
+        final StorageSharedTreeMapStoreValue value = this.store.load(path)
+            .orElse(null);
+        if(null !=value) {
+            if(value.parent) {
+                throw path.invalidStoragePathException("Invalid parent path");
+            }
+
+            this.store.delete(path);
+        }
     }
 
     @Override
@@ -164,30 +167,43 @@ final class StorageSharedTreeMapStore<C extends StorageContext> extends StorageS
                                  final C context) {
         this.saveRootIfNecessary(context);
 
-        final Stream<StorageSharedTreeMapStoreValue> listing = parent.isParent() ?
-            this.store.all()
-                .stream()
-                .filter(i -> parent.equals(i.path().parent().orElse(null)))
-                .skip(offset)
-                .limit(count) :
-            0 == offset && count > 0 ?
-                this.store.load(parent)
-                    .stream() :
-                Stream.empty();
+        final StoragePath parentWithSlash = parent.parentWithoutTrailingSeparator();
 
-        return listing.map(StorageSharedTreeMapStoreValue::info)
-            .collect(
-                Collectors.collectingAndThen(
-                    Collectors.toList(),
-                    StorageValueInfoList::with
-                )
-            );
+        StorageSharedTreeMapStoreValue value = this.store.load(parentWithSlash)
+            .orElse(null);
+
+        StorageValueInfoList storageValueInfoList = StorageValueInfoList.EMPTY;
+
+        if(null != value) {
+            if(value.parent) {
+                storageValueInfoList = this.store.all()
+                    .stream()
+                    .filter(i -> parentWithSlash.equals(i.path().parent().orElse(null)))
+                    .skip(offset)
+                    .limit(count)
+                    .map(StorageSharedTreeMapStoreValue::info)
+                    .collect(
+                        Collectors.collectingAndThen(
+                            Collectors.toList(),
+                            StorageValueInfoList::with
+                        )
+                    );
+
+            } else {
+                storageValueInfoList = StorageValueInfoList.EMPTY.concat(value.info);
+            }
+        } else {
+            storageValueInfoList = StorageValueInfoList.EMPTY;
+        }
+
+        return storageValueInfoList;
     }
 
     private void saveRootIfNecessary(final StorageContext context) {
         if (this.store.count() == 0) {
             this.store.save(
                 StorageSharedTreeMapStoreValue.with(
+                    true, // parent
                     StorageValueInfo.with(
                         StoragePath.ROOT,
                         context.createdAuditInfo()

--- a/src/main/java/walkingkooka/storage/StorageSharedTreeMapStoreValue.java
+++ b/src/main/java/walkingkooka/storage/StorageSharedTreeMapStoreValue.java
@@ -29,16 +29,26 @@ import java.util.Optional;
  */
 final class StorageSharedTreeMapStoreValue implements HasId<Optional<StoragePath>> {
 
-    static StorageSharedTreeMapStoreValue with(final StorageValueInfo info,
+    final static boolean NOT_PARENT = false;
+
+    final static boolean PARENT = true;
+
+    static StorageSharedTreeMapStoreValue with(final boolean parent,
+                                               final StorageValueInfo info,
                                                final StorageValue value) {
         return new StorageSharedTreeMapStoreValue(
+            parent,
             Objects.requireNonNull(info, "info"),
             Objects.requireNonNull(value, "value")
         );
     }
 
-    private StorageSharedTreeMapStoreValue(final StorageValueInfo info,
+    private StorageSharedTreeMapStoreValue(final boolean parent,
+                                           final StorageValueInfo info,
                                            final StorageValue value) {
+        super();
+
+        this.parent = parent;
         this.info = info;
         this.value = value;
     }
@@ -50,6 +60,7 @@ final class StorageSharedTreeMapStoreValue implements HasId<Optional<StoragePath
         return this.info.equals(info) && this.value.equals(value) ?
             this :
             StorageSharedTreeMapStoreValue.with(
+                this.parent,
                 info,
                 value
             );
@@ -68,6 +79,11 @@ final class StorageSharedTreeMapStoreValue implements HasId<Optional<StoragePath
         return this.value.path();
     }
 
+    /**
+     * Keeps track whether this entry is a parent of other entries.
+     */
+    boolean parent;
+
     // info.............................................................................................................
 
     StorageValueInfo info() {
@@ -80,6 +96,7 @@ final class StorageSharedTreeMapStoreValue implements HasId<Optional<StoragePath
         return this.info.equals(info) ?
             this :
             StorageSharedTreeMapStoreValue.with(
+                this.parent,
                 info,
                 this.value
             );
@@ -97,7 +114,8 @@ final class StorageSharedTreeMapStoreValue implements HasId<Optional<StoragePath
         return this.value.equals(value) ?
             this :
             StorageSharedTreeMapStoreValue.with(
-                info,
+                this.parent,
+                this.info,
                 value
             );
     }
@@ -107,6 +125,7 @@ final class StorageSharedTreeMapStoreValue implements HasId<Optional<StoragePath
     @Override
     public int hashCode() {
         return Objects.hash(
+            this.parent,
             this.info,
             this.value
         );
@@ -120,7 +139,8 @@ final class StorageSharedTreeMapStoreValue implements HasId<Optional<StoragePath
     }
 
     private boolean equals0(final StorageSharedTreeMapStoreValue other) {
-        return this.info.equals(other.info) &&
+        return this.parent == other.parent &&
+            this.info.equals(other.info) &&
             this.value.equals(other.value);
     }
 

--- a/src/test/java/walkingkooka/storage/StoragePathTest.java
+++ b/src/test/java/walkingkooka/storage/StoragePathTest.java
@@ -16,6 +16,7 @@
  */
 package walkingkooka.storage;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import walkingkooka.InvalidTextLengthException;
 import walkingkooka.collect.set.Sets;
@@ -24,6 +25,7 @@ import walkingkooka.naming.PathTesting;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.test.ParseStringTesting;
+import walkingkooka.text.CharSequences;
 import walkingkooka.text.printer.TreePrintableTesting;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeMarshallingTesting;
@@ -98,6 +100,22 @@ HasCurrentWorkingDirectoryTesting,
     }
 
     @Test
+    public void testParseTrailSlash() {
+        final String value = "/path1/";
+
+        final StoragePath path = StoragePath.parse(value);
+        this.valueAndCheck(
+            path,
+            value
+        );
+        this.nameCheck(
+            path,
+            StorageName.with("path1")
+        );
+        this.parentCheck(path);
+    }
+
+    @Test
     public void testParseSlashHome() {
         final String value = "/home";
 
@@ -146,7 +164,7 @@ HasCurrentWorkingDirectoryTesting,
         );
         this.parentCheck(
             path,
-            "/path1/"
+            "/path1"
         );
     }
 
@@ -163,7 +181,7 @@ HasCurrentWorkingDirectoryTesting,
         );
         this.parentCheck(
             path,
-            "/path1/"
+            "/path1"
         );
     }
 
@@ -179,7 +197,7 @@ HasCurrentWorkingDirectoryTesting,
         );
         this.parentCheck(
             path,
-            "/path/"
+            "/path"
         );
     }
 
@@ -195,7 +213,7 @@ HasCurrentWorkingDirectoryTesting,
         );
         this.parentCheck(
             path,
-            "/path/"
+            "/path"
         );
     }
 
@@ -213,7 +231,7 @@ HasCurrentWorkingDirectoryTesting,
 
         this.parentCheck(
             path,
-            "/path/to/"
+            "/path/to"
         );
 
         final StoragePath parent = path.parent()
@@ -221,7 +239,7 @@ HasCurrentWorkingDirectoryTesting,
 
         this.valueAndCheck(
             parent,
-            "/path/to/"
+            "/path/to"
         );
         this.rootNotCheck(parent);
         this.nameCheck(
@@ -230,7 +248,7 @@ HasCurrentWorkingDirectoryTesting,
         );
         this.parentCheck(
             parent,
-            "/path/"
+            "/path"
         );
     }
 
@@ -248,7 +266,7 @@ HasCurrentWorkingDirectoryTesting,
 
         this.parentCheck(
             path,
-            "/path/to/"
+            "/path/to"
         );
 
         final StoragePath parent = path.parent()
@@ -256,7 +274,7 @@ HasCurrentWorkingDirectoryTesting,
 
         this.valueAndCheck(
             parent,
-            "/path/to/"
+            "/path/to"
         );
         this.rootNotCheck(parent);
         this.nameCheck(
@@ -265,7 +283,7 @@ HasCurrentWorkingDirectoryTesting,
         );
         this.parentCheck(
             parent,
-            "/path/"
+            "/path"
         );
     }
 
@@ -289,7 +307,7 @@ HasCurrentWorkingDirectoryTesting,
 
         this.parentCheck(
             path,
-            "/path1/path2/"
+            "/path1/path2"
         );
     }
 
@@ -298,7 +316,7 @@ HasCurrentWorkingDirectoryTesting,
         final StoragePath path = StoragePath.parse("/path1/path2/path3/.");
         this.valueAndCheck(
             path,
-            "/path1/path2/path3/"
+            "/path1/path2/path3"
         );
         this.rootNotCheck(path);
         this.nameCheck(
@@ -308,7 +326,7 @@ HasCurrentWorkingDirectoryTesting,
 
         this.parentCheck(
             path,
-            "/path1/path2/"
+            "/path1/path2"
         );
     }
 
@@ -327,7 +345,7 @@ HasCurrentWorkingDirectoryTesting,
 
         this.parentCheck(
             path,
-            "/path1/"
+            "/path1"
         );
     }
 
@@ -346,7 +364,7 @@ HasCurrentWorkingDirectoryTesting,
 
         this.parentCheck(
             path,
-            "/path1/"
+            "/path1"
         );
     }
 
@@ -355,7 +373,7 @@ HasCurrentWorkingDirectoryTesting,
         final StoragePath path = StoragePath.parse("/path1/path2/path3/..");
         this.valueAndCheck(
             path,
-            "/path1/path2/"
+            "/path1/path2"
         );
         this.rootNotCheck(path);
         this.nameCheck(
@@ -365,7 +383,7 @@ HasCurrentWorkingDirectoryTesting,
 
         this.parentCheck(
             path,
-            "/path1/"
+            "/path1"
         );
     }
 
@@ -757,6 +775,15 @@ HasCurrentWorkingDirectoryTesting,
     @Test
     public void testPrependPath2() {
         this.prependPathAndCheck(
+            "/path3",
+            "/path1/path2/",
+            "/path1/path2/path3"
+        );
+    }
+
+    @Test
+    public void testPrependPath3() {
+        this.prependPathAndCheck(
             "/path3/path4",
             "/path1/path2",
             "/path1/path2/path3/path4"
@@ -764,7 +791,7 @@ HasCurrentWorkingDirectoryTesting,
     }
 
     @Test
-    public void testPrependPath3() {
+    public void testPrependPath4() {
         this.prependPathAndCheck(
             "/path3/path4",
             "/path1/./lost/../path2",
@@ -1418,6 +1445,19 @@ HasCurrentWorkingDirectoryTesting,
                 }
             ),
             path::toString
+        );
+    }
+
+    @Override
+    public void parentCheck(final StoragePath path,
+                            final String value) {
+        if (value.endsWith(StoragePath.SEPARATOR_STRING)) {
+            Assertions.fail("Path " + CharSequences.quote(value) + " must NOT end with " + CharSequences.quote(StoragePath.SEPARATOR_STRING));
+        }
+
+        PathTesting.super.parentCheck(
+            path,
+            value
         );
     }
 

--- a/src/test/java/walkingkooka/storage/StorageSharedTreeMapStoreTest.java
+++ b/src/test/java/walkingkooka/storage/StorageSharedTreeMapStoreTest.java
@@ -364,7 +364,7 @@ public class StorageSharedTreeMapStoreTest extends StorageSharedTestCase<Storage
 
         this.getMessageAndCheck(
             thrown,
-            "Invalid parent path \"/parent1/\""
+            "Invalid parent path \"/parent1\""
         );
     }
 
@@ -468,7 +468,11 @@ public class StorageSharedTreeMapStoreTest extends StorageSharedTestCase<Storage
             10,
             context,
             StorageValueInfo.with(
-                parent,
+                file2,
+                AUDIT_INFO
+            ),
+            StorageValueInfo.with(
+                file3,
                 AUDIT_INFO
             )
         );

--- a/src/test/java/walkingkooka/storage/StorageSharedTreeMapStoreValueTest.java
+++ b/src/test/java/walkingkooka/storage/StorageSharedTreeMapStoreValueTest.java
@@ -80,6 +80,7 @@ public final class StorageSharedTreeMapStoreValueTest implements HashCodeEqualsD
         assertThrows(
             NullPointerException.class,
             () -> StorageSharedTreeMapStoreValue.with(
+                StorageSharedTreeMapStoreValue.NOT_PARENT,
                 null,
                 VALUE
             )
@@ -91,6 +92,7 @@ public final class StorageSharedTreeMapStoreValueTest implements HashCodeEqualsD
         assertThrows(
             NullPointerException.class,
             () -> StorageSharedTreeMapStoreValue.with(
+                StorageSharedTreeMapStoreValue.NOT_PARENT,
                 STORAGE_VALUE_INFO,
                 null
             )
@@ -100,6 +102,7 @@ public final class StorageSharedTreeMapStoreValueTest implements HashCodeEqualsD
     @Test
     public void testWith() {
         final StorageSharedTreeMapStoreValue value = StorageSharedTreeMapStoreValue.with(
+            StorageSharedTreeMapStoreValue.NOT_PARENT,
             STORAGE_VALUE_INFO,
             VALUE
         );
@@ -282,6 +285,7 @@ public final class StorageSharedTreeMapStoreValueTest implements HashCodeEqualsD
     public void testEqualsDifferentInfo() {
         this.checkNotEquals(
             StorageSharedTreeMapStoreValue.with(
+                StorageSharedTreeMapStoreValue.NOT_PARENT,
                 STORAGE_VALUE_INFO.setAuditInfo(
                     AUDIT_INFO.setModifiedTimestamp(
                         MODIFIED_TIMESTAMP.plusYears(1)
@@ -296,6 +300,7 @@ public final class StorageSharedTreeMapStoreValueTest implements HashCodeEqualsD
     public void testEqualsDifferentValue() {
         this.checkNotEquals(
             StorageSharedTreeMapStoreValue.with(
+                StorageSharedTreeMapStoreValue.NOT_PARENT,
                 STORAGE_VALUE_INFO,
                 VALUE.setValue(
                     Optional.of("Different")
@@ -307,6 +312,7 @@ public final class StorageSharedTreeMapStoreValueTest implements HashCodeEqualsD
     @Override
     public StorageSharedTreeMapStoreValue createObject() {
         return StorageSharedTreeMapStoreValue.with(
+            StorageSharedTreeMapStoreValue.NOT_PARENT,
             STORAGE_VALUE_INFO,
             VALUE
         );
@@ -326,6 +332,7 @@ public final class StorageSharedTreeMapStoreValueTest implements HashCodeEqualsD
     public void testToStringWithContentType() {
         this.toStringAndCheck(
             StorageSharedTreeMapStoreValue.with(
+                StorageSharedTreeMapStoreValue.NOT_PARENT,
                 STORAGE_VALUE_INFO,
                 VALUE.setContentType(
                     Optional.of(

--- a/src/test/java/walkingkooka/storage/StorageSharedWrapperExplodedZipFileTest.java
+++ b/src/test/java/walkingkooka/storage/StorageSharedWrapperExplodedZipFileTest.java
@@ -25,7 +25,6 @@ import walkingkooka.HasCharsetTesting;
 import walkingkooka.environment.AuditInfo;
 import walkingkooka.net.email.EmailAddress;
 import walkingkooka.storage.StorageSharedWrapperExplodedZipFileTest.TestStorageContext;
-import walkingkooka.text.CharSequences;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -183,15 +182,8 @@ public final class StorageSharedWrapperExplodedZipFileTest extends StorageShared
             4,
             new TestStorageContext(),
             StorageValueInfo.with(
-                StoragePath.parse(
-                    CharSequences.subSequence(
-                        FILE_STORAGE_PATH.parent()
-                            .get()
-                            .value(),
-                        0,
-                        -1
-                    ).toString()
-                ),
+                FILE_STORAGE_PATH.parent()
+                    .get(),
                 AUDIT_INFO
             )
         );


### PR DESCRIPTION
- StoragePath.parse with paths that were normalized could create instances where the parent had a trailing slash, eg a path ending with . or ...